### PR TITLE
Delete query include CSS selector special chars

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -66,7 +66,7 @@
 <% if queries.size > 0 %>
 <table class="table">
   <tr><th>Group</th><th>Query name</th><th>Targets</th><th>Query</th><th style="text-align:right;">Events</th><th></th><th></th></tr>
-  <% queries.each do |query| %>
+  <% queries.each_with_index do |query, index| %>
   <tr>
     <td><%= query.group || "(default)" %></td>
     <td><%= query.name %></td>
@@ -83,12 +83,12 @@
       <% end %>
     </td>
     <td>
-      <a class="btn btn-danger btn-xs" data-toggle="modal" href="#removeQuery<%= query.name %>">
+      <a class="btn btn-danger btn-xs" data-toggle="modal" href="#removeQuery<%= index %>">
         <span class="glyphicon glyphicon-trash"></span>
       </a>
       <div class="modal fade"
-        id="removeQuery<%= query.name %>"
-        tabindex="-1" role="dialog" aria-labelledby="removeQueryLabel<%= query.name %>" aria-hidden="true">
+        id="removeQuery<%= index %>"
+        tabindex="-1" role="dialog" aria-labelledby="removeQueryLabel<%= index %>" aria-hidden="true">
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
Web UI can create query that name include CSS selector special chars (like space, percent, etc...), but cannot delete it caused CSS selector syntax error like this:

```
Uncaught Error: Syntax error, unrecognized expression: #removeQuery100% jquery.js:1471
Sizzle.error jquery.js:1471
tokenize jquery.js:2085
select jquery.js:2473
Sizzle jquery.js:880
jQuery.fn.extend.find jquery.js:2684
jQuery.fn.init jquery.js:2801
jQuery jquery.js:75
(anonymous function) bootstrap.min.js:6
jQuery.event.dispatch jquery.js:4624
elemData.handle
```

"Query name cannot include CSS selector special chars" is norikra's specification?
If this is a spec, I think add validation is better.
If this is not specification, I want to fix this and this PR is fix this.
