### PR TITLE
fixed type_convert. (Hash to Hash, Array to Array)

### DIFF
--- a/lib/norikra/engine.rb
+++ b/lib/norikra/engine.rb
@@ -256,10 +256,10 @@ module Norikra
 
         trace "converting", :value => value
 
-        if value.respond_to?(:to_a)
-          value.to_a.map{|v| type_convert(v) }
-        elsif value.respond_to?(:to_hash)
+        if value.respond_to?(:to_hash)
           Hash[ value.to_hash.map{|k,v| [ Norikra::Field.unescape_name(k), type_convert(v)] } ]
+        elsif value.respond_to?(:to_a)
+          value.to_a.map{|v| type_convert(v) }
         elsif value.respond_to?(:force_encoding)
           value.force_encoding('UTF-8')
         else


### PR DESCRIPTION
Both array class and hash class have "to_a" method.
So, 'value' is converted to array object when it is hash object.
- Norikra v1.0.1

``` bash
# norikra-client query add ex "SELECT percentiles(num_field,{50,95}) FROM foo"
# echo '{ "num_field":1 }' | norikra-client event send foo
# norikra-client event fetch ex
{"time":"2014/06/01 20:24:10","percentiles(num_field)":{"95":1.0,"50":1.0}}
```

and in WebUI, the event shows

```
[1401623886,{"percentiles(num_field)":{"50":1,"95":1}}]
```
- Norikra v1.0.2,

``` bash
# norikra start -d --logdir=/var/log/norikra  --pidfile=/var/run/norikra.pid
# norikra-client query add ex "SELECT percentiles(num_field,{50,95}) FROM foo"
# echo '{ "num_field":1 }' | norikra-client event send foo
# norikra-client event fetch ex
TypeError: can't convert Array into Hash
           merge at org/jruby/RubyHash.java:1763
           fetch at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/norikra-client-jruby-1.0.0-java/lib/norikra/client/cli.rb:168
            each at org/jruby/RubyArray.java:1613
           fetch at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/norikra-client-jruby-1.0.0-java/lib/norikra/client/cli.rb:167
            wrap at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/norikra-client-jruby-1.0.0-java/lib/norikra/client/cli.rb:14
           fetch at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/norikra-client-jruby-1.0.0-java/lib/norikra/client/cli.rb:166
             run at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/command.rb:27
  invoke_command at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/invocation.rb:126
        dispatch at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor.rb:359
          invoke at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/invocation.rb:115
           event at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor.rb:235
             run at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/command.rb:27
  invoke_command at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/invocation.rb:126
        dispatch at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor.rb:359
           start at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/thor-0.19.1/lib/thor/base.rb:440
          (root) at /.rbenv/versions/jruby-1.7.11/lib/ruby/gems/shared/gems/norikra-client-jruby-1.0.0-java/bin/norikra-client:8
            load at org/jruby/RubyKernel.java:1101
          (root) at //.rbenv/versions/jruby-1.7.11/bin/norikra-client:23
```

And in WebUI, the result event shows

```
[1401623385,[["percentiles(num_field)",[["95",1],["50",1]]]]]
```

This pull request is to fix this problem.
