### PR TITLE
add --log4j-properties option for using external logger settings

### DIFF
--- a/lib/norikra/cli.rb
+++ b/lib/norikra/cli.rb
@@ -68,7 +68,7 @@ module Norikra
         option :'log-filesize', :type => :string, :default => nil, :desc => 'log rotation size [10MB]'
         option :'log-backups' , :type => :numeric, :default => nil, :desc => 'log rotation backups [10]'
         option :'log-buffer-lines', :type => :numeric, :default => nil, :desc => 'log lines to fetch from API [1000]'
-        option :'log4j-properties', :type => :string, :default => nil, :desc => 'path to log4j.properties. ignore other log* options when this option is present'
+        option :'log4j-properties-path', :type => :string, :default => nil, :desc => 'path to log4j.properties. ignore other log* options when this option is present'
 
         ### Loglevel options
         option :'more-quiet',   :type => :boolean, :default => false,                   :desc => 'set loglevel as ERROR'
@@ -227,7 +227,7 @@ module Norikra
         filesize: options[:'log-filesize'], backups: options[:'log-backups'],
         bufferlines: options[:'log-buffer-lines'],
       }
-      conf[:log4j_properties] = options[:'log4j-properties']
+      conf[:log4j_properties_path] = options[:'log4j-properties-path']
 
       server_options = {
         host: options[:host],

--- a/lib/norikra/logger.rb
+++ b/lib/norikra/logger.rb
@@ -106,8 +106,8 @@ module Norikra
       @@devmode = devmode
     end
 
-    def self.init_with_log4j_properties(log4j_properties)
-      org.apache.log4j.PropertyConfigurator.configure(log4j_properties)
+    def self.init_with_log4j_properties_path(log4j_properties_path)
+      org.apache.log4j.PropertyConfigurator.configure(log4j_properties_path)
       @@logger = Logger.new('norikra.log')
       @@devmode = false
     end

--- a/lib/norikra/server.rb
+++ b/lib/norikra/server.rb
@@ -96,10 +96,10 @@ module Norikra
 
       @thread_conf = self.class.threading_configuration(conf[:thread])
       @log_conf = self.class.log_configuration(conf[:log])
-      @log4j_properties = conf[:log4j_properties]
+      @log4j_properties_path = conf[:log4j_properties_path]
 
-      if @log4j_properties
-        Norikra::Log.init_with_log4j_properties(@log4j_properties)
+      if @log4j_properties_path
+        Norikra::Log.init_with_log4j_properties_path(@log4j_properties_path)
       else
         Norikra::Log.init(@log_conf[:level], @log_conf[:dir], {filesize: @log_conf[:filesize], backups: @log_conf[:backups], bufferlines: @log_conf[:bufferlines]})
       end


### PR DESCRIPTION
ログの設定を外部から細かく制御したかったのでlog4j.propertiesを指定するオプションを追加。
それに伴い2点リファクタリング。
- 不必要なインスタンス変数の削除
- デバッグレベルのチェックをLoggerに移譲
