### PR TITLE
enable '-javaagent' option

### DIFF
--- a/lib/norikra/cli.rb
+++ b/lib/norikra/cli.rb
@@ -144,6 +144,8 @@ module Norikra
           jruby_options.push('-J-X' + $1)
         elsif arg =~ /^-verbose:gc$/
           jruby_options.push('-J-verbose:gc')
+        elsif arg =~ /^-javaagent:(.+)$/
+          jruby_options.push('-J-javaagent:' + $1)
         else
           argv.push(arg)
         end


### PR DESCRIPTION
I want to monitor Norikra with [jolokia](http://jolokia.org).
This patch enables `-javaagent` option.

`$ norikra start -javaagent:/usr/local/lib/jolokia-jvm-1.2.3-agent.jar`
