### PR TITLE
fix to load stats file containing multibyte character

### DIFF
--- a/lib/norikra/stats.rb
+++ b/lib/norikra/stats.rb
@@ -45,7 +45,7 @@ module Norikra
     end
 
     def self.load(path)
-      File.open(path, 'r', :external_encoding=>'utf-8') do |file|
+      File.open(path, 'r', external_encoding: 'utf-8') do |file|
         self.new(JSON.parse(file.read, symbolize_names: true))
       end
     end

--- a/lib/norikra/stats.rb
+++ b/lib/norikra/stats.rb
@@ -45,7 +45,7 @@ module Norikra
     end
 
     def self.load(path)
-      File.open(path, 'r') do |file|
+      File.open(path, 'r', :external_encoding=>'utf-8') do |file|
         self.new(JSON.parse(file.read, symbolize_names: true))
       end
     end


### PR DESCRIPTION
Fix failed to restart when `stats.json` contains multibyte character and `Encoding.default_external` is not UTF-8. `dump` is succeeded, but `load` is failed.