### PR TITLE
Add ui-context-path option.

### DIFF
--- a/lib/norikra/cli.rb
+++ b/lib/norikra/cli.rb
@@ -28,6 +28,8 @@ module Norikra
         option :'shutoff-threshold', type: :numeric, default: 90, desc: 'threshold percent of heap memory usage to turn "shutoff mode" on'
         option :'shutoff-check-interval', type: :numeric, default: 10, desc: 'interval seconds to turn "shutoff mode" on/off'
 
+        option :'ui-context-path', type: :string, default: nil, desc: 'Web UI context path'
+
         ### Daemonize options
         option :daemonize, type: :boolean, default: false, aliases: "-d", \
                            desc: 'daemonize Norikra server [false (foreground)]'
@@ -251,6 +253,7 @@ module Norikra
         host: options[:host],
         port: options[:port],
         ui_port: options[:'ui-port'],
+        ui_context_path: options[:'ui-context-path'],
       }
 
       server = Norikra::Server.new( server_options, conf )

--- a/lib/norikra/server.rb
+++ b/lib/norikra/server.rb
@@ -101,6 +101,8 @@ module Norikra
       @port = server_options[:port] || Norikra::RPC::HTTP::DEFAULT_LISTEN_PORT
       @ui_port = server_options[:ui_port] || Norikra::WebUI::HTTP::DEFAULT_LISTEN_PORT
 
+      @ui_context_path = server_options[:ui_context_path] || "/"
+
       @thread_conf = self.class.threading_configuration(conf[:thread])
       @log_conf = self.class.log_configuration(conf[:log])
       @log4j_properties_path = conf[:log4j_properties_path]
@@ -134,7 +136,8 @@ module Norikra
       @webserver = Norikra::WebUI::HTTP.new(
         engine: @engine,
         host: @host, port: @ui_port,
-        threads: @thread_conf[:web][:threads]
+        threads: @thread_conf[:web][:threads],
+        context_path: @ui_context_path
       )
     end
 

--- a/lib/norikra/webui.rb
+++ b/lib/norikra/webui.rb
@@ -1,6 +1,7 @@
 module Norikra::WebUI
 end
 
+require 'norikra/webui/helpers'
 require 'norikra/webui/handler'
 require 'norikra/webui/api'
 require 'norikra/webui/http'

--- a/lib/norikra/webui/handler.rb
+++ b/lib/norikra/webui/handler.rb
@@ -15,6 +15,8 @@ class Norikra::WebUI::Handler < Sinatra::Base
   set :views, File.absolute_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'views'))
   set :erb, escape_html: true
 
+  helpers Norikra::WebUI::Helpers
+
   enable :sessions
 
   def norikra_version; Norikra::VERSION ; end

--- a/lib/norikra/webui/handler.rb
+++ b/lib/norikra/webui/handler.rb
@@ -103,7 +103,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
     target_name = params[:target]
     logging(:manage, :close, [target_name]) do
       engine.close(target_name)
-      redirect '/'
+      redirect url_for('/')
     end
   end
 
@@ -117,7 +117,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
           error: error_message,
         },
       }
-      redirect '/#query_add'
+      redirect url_for("/#query_add")
     }
 
     logging(:manage, :register, [query_name, query_group, expression], on_error_hook: error_hook) do
@@ -128,7 +128,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
         query_group = nil
       end
       engine.register(Norikra::Query.new(name: query_name, group: query_group, expression: expression))
-      redirect '/#queries'
+      redirect url_for("/#queries")
     end
   end
 
@@ -136,7 +136,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
     query_name = params[:query_name]
     logging(:manage, :deregister, [query_name]) do
       engine.deregister(query_name)
-      redirect '/#queries'
+      redirect url_for("/#queries")
     end
   end
 
@@ -144,7 +144,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
     query_name = params[:query_name]
     logging(:manage, :suspend, [query_name]) do
       engine.suspend(query_name)
-      redirect '/#queries'
+      redirect url_for("/#queries")
     end
   end
 
@@ -152,7 +152,7 @@ class Norikra::WebUI::Handler < Sinatra::Base
     query_name = params[:query_name]
     logging(:manage, :resume, [query_name]) do
       engine.resume(query_name)
-      redirect '/#queries'
+      redirect url_for("/#queries")
     end
   end
 

--- a/lib/norikra/webui/helpers.rb
+++ b/lib/norikra/webui/helpers.rb
@@ -1,6 +1,6 @@
 
 module Norikra::WebUI::Helpers
   def url_for(ref)
-    "#{@request.script_name}#{ref}"
+    "#{request.script_name}#{ref}"
   end
 end

--- a/lib/norikra/webui/helpers.rb
+++ b/lib/norikra/webui/helpers.rb
@@ -1,0 +1,6 @@
+
+module Norikra::WebUI::Helpers
+  def url_for(ref)
+    "#{@request.script_name}#{ref}"
+  end
+end

--- a/lib/norikra/webui/http.rb
+++ b/lib/norikra/webui/http.rb
@@ -26,10 +26,12 @@ module Norikra::WebUI
       Norikra::WebUI::Handler.engine = @engine
       Norikra::WebUI::API.engine = @engine
       @app = Rack::Builder.new {
-        map '/api' do
-          run Norikra::WebUI::API
+        map opts[:context_path] do
+          map '/api' do
+            run Norikra::WebUI::API
+          end
+          run Norikra::WebUI::Handler
         end
-        run Norikra::WebUI::Handler
       }
     end
 

--- a/views/base.erb
+++ b/views/base.erb
@@ -12,12 +12,12 @@
     <!-- TODO: logo favicon <link rel="shortcut icon" href="../../assets/ico/favicon.png"> -->
 
     <!-- Bootstrap core CSS -->
-    <link href="/css/bootstrap.css" rel="stylesheet">
+    <link href="<%= url_for("/css/bootstrap.css") %>" rel="stylesheet">
     <!-- Bootstrap theme -->
-    <link href="/css/bootstrap-theme.min.css" rel="stylesheet">
+    <link href="<%= url_for("/css/bootstrap-theme.min.css") %>" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="/css/norikra.css" rel="stylesheet">
+    <link href="<%= url_for("/css/norikra.css") %>" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -60,9 +60,8 @@
     <!-- Placed at the end of the document so the pages load faster -->
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <!-- <script src="//code.jquery.com/jquery.js"></script> -->
-    <script src="/js/jquery.min.js"></script>
-    <script src="/js/bootstrap.min.js"></script>
-    <script src="/js/norikra.webui.js"></script>
+    <script src="<%= url_for("/js/jquery.min.js") %>"></script>
+    <script src="<%= url_for("/js/bootstrap.min.js") %>"></script>
+    <script src="<%= url_for("/js/norikra.webui.js") %>"></script>
   </body>
 </html>
-

--- a/views/index.erb
+++ b/views/index.erb
@@ -75,12 +75,12 @@
     <td><%= query.targets.join(", ") %></td>
     <td><%= query.suspended? ? "suspended" : "" %></td>
     <td>
-      <button class="btn btn-default btn-xs show-query-expression" data-load="/json/query/<%= query.name %>">show query</button>
+      <button class="btn btn-default btn-xs show-query-expression" data-load="<%= url_for("/json/query/#{query.name}") %>">show query</button>
     </td>
     <td style="text-align: right;"><%= pool[query.name] %></td>
     <td>
       <% if pool[query.name].to_i > 0 %>
-      <button class="btn btn-info btn-xs show-query-events-sample" data-load="/json/events_sample/<%= query.name %>">
+      <button class="btn btn-info btn-xs show-query-events-sample" data-load="<%= url_for("/json/events_sample/#{query.name}") %>">
         <span class="glyphicon glyphicon-search"></span>
       </button>
       <% end %>
@@ -104,7 +104,7 @@
               <pre><%= query.expression %></pre>
               </div>
               <div class="modal-footer">
-                <form class="form-inline" action="/resume" method="POST">
+                <form class="form-inline" action="<%= url_for("/resume") %>" method="POST">
                   <input type="hidden" name="query_name" value="<%= query.name %>" />
                   <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                   <button type="submit" class="btn btn-primary">Resume</button>
@@ -131,7 +131,7 @@
               <pre><%= query.expression %></pre>
               </div>
               <div class="modal-footer">
-                <form class="form-inline" action="/suspend" method="POST">
+                <form class="form-inline" action="<%= url_for("/suspend") %>" method="POST">
                   <input type="hidden" name="query_name" value="<%= query.name %>" />
                   <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                   <button type="submit" class="btn btn-danger">Suspend</button>
@@ -160,7 +160,7 @@
               <pre><%= query.expression %></pre>
             </div>
             <div class="modal-footer">
-              <form class="form-inline" action="/deregister" method="POST">
+              <form class="form-inline" action="<%= url_for("/deregister") %>" method="POST">
                 <input type="hidden" name="query_name" value="<%= query.name %>" />
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 <button type="submit" class="btn btn-danger">Remove</button>
@@ -183,7 +183,7 @@
   <% if input_data[:query_add][:error] %>
     <div class="alert alert-danger"><%= input_data[:query_add][:error] %></div>
   <% end %>
-  <form action="/register", method="POST">
+  <form action="<%= url_for("/register") %>", method="POST">
     <div class="row">
       <div class="col-sm-8 form-group">
         <label for="addQueryExpression">Query</label>
@@ -242,7 +242,7 @@
               <p>name: <%= target[:name] %></p>
             </div>
             <div class="modal-footer">
-              <form class="form-inline" action="/close" method="POST">
+              <form class="form-inline" action="<%= url_for("/close") %>" method="POST">
                 <input type="hidden" name="target" value="<%= target[:name] %>" />
                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                 <button type="submit" class="btn btn-danger">Remove</button>
@@ -263,13 +263,13 @@
   <h1 id="stats">Target/Query stat dump</h1>
 </div>
 
-<a href="/stat/dump" class="btn btn-info btn-lg" role="button">Download JSON</a>
+<a href="<%= url_for("/stat/dump") %>" class="btn btn-info btn-lg" role="button">Download JSON</a>
 
 <div class="page-header">
   <h1 id="logs">Server logs</h1>
 </div>
 
-<button id="show_server_logs" class="btn btn-info btn-lg" data-url="/logs">Show server logs</button>
+<button id="show_server_logs" class="btn btn-info btn-lg" data-url="<%= url_for("/logs") %>">Show server logs</button>
 
 <div id="logsection" style="display: none;">
   <table id="logtable" class="table logs">

--- a/views/index.erb
+++ b/views/index.erb
@@ -183,7 +183,7 @@
   <% if input_data[:query_add][:error] %>
     <div class="alert alert-danger"><%= input_data[:query_add][:error] %></div>
   <% end %>
-  <form action="<%= url_for("/register") %>", method="POST">
+  <form action="<%= url_for("/register") %>" method="POST">
     <div class="row">
       <div class="col-sm-8 form-group">
         <label for="addQueryExpression">Query</label>

--- a/views/index.erb
+++ b/views/index.erb
@@ -218,7 +218,7 @@
     <td><%= target[:auto_field] %></td>
     <td>
       <% if target[:fields].size > 0 %>
-        <button class="btn btn-default btn-xs show-target-fields" data-load="/json/target/<%= target[:name] %>">show fields</button>
+        <button class="btn btn-default btn-xs show-target-fields" data-load="<%= url_for("/json/target/#{target[:name]}") %>">show fields</button>
       <% else %>
         (lazy target)
       <% end %>


### PR DESCRIPTION
This option allows that Web UI maps particular endpoint such as `http://any-server.local/norikra/`.
When `--ui-context-path` option is specified, All endpoints mapped to the specified context path and use context path as asset url prefix.

The option name is borrowed from Tomcat or Play Framework.

BTW, we need more test for web ui.