### PR TITLE
Add engine_statistics api endpoint.

### DIFF
--- a/lib/norikra/webui/api.rb
+++ b/lib/norikra/webui/api.rb
@@ -186,5 +186,11 @@ class Norikra::WebUI::API < Sinatra::Base
     }
   end
 
+  get '/engine_statistics' do
+    logging(:show, :json_engine_statistics) do
+      json engine.statistics
+    end
+  end
+
   # post('/listen') # get all events as stream, during connection keepaliving
 end


### PR DESCRIPTION
```
curl -s localhost:26578/api/engine_statistics | python -mjson.tool                                                                                                             (git:feature/engine_statistics_api)[~/repo/norikra]
{
    "input_events": 0,
    "memory": {
        "heap": {
            "committed": 112,
            "committed_percent": 25.6,
            "max": 437,
            "used": 44,
            "used_percent": 10.0
        },
        "nonheap": {
            "committed": 42,
            "committed_percent": 32.3,
            "max": 130,
            "used": 41,
            "used_percent": 31.5
        }
    },
    "output_events": 0,
    "processed_events": 0,
    "queries": 0,
    "started": "Thu, 02 Apr 2015 12:32:14 +0900",
    "targets": 0,
    "uptime": "0 days, 00:01"
}
```