### PR TITLE
'norikra start' with java system property

### DIFF
--- a/lib/norikra/cli.rb
+++ b/lib/norikra/cli.rb
@@ -152,6 +152,8 @@ module Norikra
           jruby_options.push('-J-verbose:gc')
         elsif arg =~ /^-javaagent:(.+)$/
           jruby_options.push('-J-javaagent:' + $1)
+        elsif arg =~ /^-D(.+)$/
+          jruby_options.push('-J-D' + $1)
         else
           argv.push(arg)
         end


### PR DESCRIPTION
I want to start norikra with java system option(such as `-Dcom.sun.management.jmxremote=true` to enable JMX monitoring).
This patch enables -D option to `norikra start`.