### PR TITLE
add edit query feature

### DIFF
--- a/lib/norikra/engine.rb
+++ b/lib/norikra/engine.rb
@@ -218,6 +218,21 @@ module Norikra
       end
     end
 
+    def replace(query)
+      info "replacing query", name: query.name, targets: query.targets, expression: query.expression
+      if @queries.select{|q| q.name == query.name }.size == 0 &&
+         @suspended_queries.select{|q| q.name == query.name }.size == 0
+        raise Norikra::ClientError, "query name '#{query.name}' does not exists"
+      end
+
+      if reason = query.invalid?
+        raise Norikra::ClientError, "invalid query '#{query.name}': #{reason}"
+      end
+
+      deregister(query.name)
+      register(query)
+    end
+
     def suspend(query_name)
       info "suspending query", name: query_name
       queries = @queries.select{|q| q.name == query_name }

--- a/lib/norikra/rpc/handler.rb
+++ b/lib/norikra/rpc/handler.rb
@@ -84,6 +84,13 @@ class Norikra::RPC::Handler
     }
   end
 
+  def replace(query_name, query_group, expression)
+    logging(:manage, :replace, [query_name, query_group, expression]){
+      r = @engine.replace(Norikra::Query.new(name: query_name, group: query_group, expression: expression))
+      !!r
+    }
+  end
+
   def suspend(query_name)
     logging(:manage, :suspend, [query_name]){
       r = @engine.suspend(query_name)

--- a/lib/norikra/webui/api.rb
+++ b/lib/norikra/webui/api.rb
@@ -132,6 +132,14 @@ class Norikra::WebUI::API < Sinatra::Base
     }
   end
 
+  post '/replace' do
+    query_name, query_group, expression = args = parse_args(['query_name', 'query_group', 'expression'], request)
+    logging(:manage, :replace, args){
+      r = engine.replace(Norikra::Query.new(name: query_name, group: query_group, expression: expression))
+      json result: (!!r)
+    }
+  end
+
   get '/fields' do
     target, = args = parse_args(['target'], request)
     logging(:show, :fields, args){

--- a/public/js/norikra.webui.js
+++ b/public/js/norikra.webui.js
@@ -1,24 +1,5 @@
 $(function(){
 
-  $('.show-query-expression').each(function(i,e){
-    $(this).bind('click', function(e){
-      var button = $(this);
-      if (! button.data('loaded')) {
-        $.get(button.data('load'), function(data){
-          button.attr('data-loaded', 'true');
-          button.popover({
-            placement: 'left',
-            html: true,
-            title: 'name:' + data.name + ', group:' + data.group,
-            content: '<pre class="query-expression" style="border: none; width: 100%;">' + data.expression + '</pre>'
-          }).popover('toggle');
-          $('pre.query-expression').closest('div').css('padding', '0');
-        });
-        e.preventDefault();
-      }
-    });
-  });
-
   $('.show-query-events-sample').each(function(i,e){
     $(this).bind('click', function(e){
       var button = $(this);

--- a/views/index.erb
+++ b/views/index.erb
@@ -75,7 +75,33 @@
     <td><%= query.targets.join(", ") %></td>
     <td><%= query.suspended? ? "suspended" : "" %></td>
     <td>
-      <button class="btn btn-default btn-xs show-query-expression" data-load="<%= url_for("/json/query/#{query.name}") %>">show query</button>
+      <a class="btn btn-info btn-xs" data-toggle="modal" href="#editQuery<%= index %>">
+        <span class="glyphicon glyphicon-edit"></span>
+      </a>
+      <div class="modal fade"
+           id="editQuery<%= index %>"
+           tabindex="-1" role="dialog" aria-labelledby="editQueryLabel<%= index %>" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+              <h4 class="modal-title">Edit Query <%= query.name %></h4>
+            </div>
+            <form action="<%= url_for("/replace") %>" method="POST">
+              <div class="modal-body">
+                <p>name: <%= query.name %>, group: <%= query.group || "(default)" %></p>
+                <input type="hidden" name="query_name" value="<%= query.name %>"/>
+                <input type="hidden" name="query_group" value="<%= query.group %>"/>
+                <textarea name="expression" class="form-control" rows="5"><%= query.expression %></textarea>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <button type="submit" class="btn btn-warning">Submit</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </td>
     <td style="text-align: right;"><%= pool[query.name] %></td>
     <td>
@@ -175,6 +201,11 @@
 </table>
 <% else %>
 <p>No queries found.</p>
+<% end %>
+
+<% input_data ||= {}; input_data[:query_replace] ||= {} %>
+<% if input_data[:query_replace][:error] %>
+  <div class="alert alert-danger"><%= input_data[:query_replace][:error] %></div>
 <% end %>
 
 <h3 id="query_add">Add Query <button class="btn btn-warning btn-xs" id="query_add_editor_toggle">editor</button></h3>


### PR DESCRIPTION
### Motivation

Now it is impossible to edit query.
If users want to edit a query, they need to remove a query that already exists and register a new query.
This is a time-consuming and is a data loss while users edit query.
So, I want an edit query feature.
### Design

I think that "show query" link is not necessary if an edit query feature is implemented.
So, I remove "show query" link.
I add "replace" as API because "modify" API already exists.
### Screenshot

The following is an edit query modal dialog. I implemented by reference to "suspend" and "resume"
![](https://gyazo.com/f484af847b49eff2a8b1346782ea5491.png)

If you submit a syntax error query, the following is a result.
![](https://gyazo.com/721fbc29a8d05f28a16b12425f95f54d.png)

I check at `bundle exec rake devserver` and there is no problem.
So, please check this pull request.

Regards
