### PR TITLE
Fix the problem that the part of fields only appears in the case of too long fields.

### DIFF
--- a/public/js/norikra.webui.js
+++ b/public/js/norikra.webui.js
@@ -60,6 +60,7 @@ $(function(){
           button.popover({
             placement: 'top',
             html: true,
+            template: '<div class="popover" role="tooltip" style="height: 50%; overflow-y: scroll;"><div class="arrow"></div><h3 class="popover-title"></h3><div class="popover-content"></div></div>',
             content: table_html
           }).popover('toggle');
           $('table.target-fields').closest('div').css('padding', '0');


### PR DESCRIPTION
The current Norikra cannot handle too long fields as shown in the following figure.

![2015-12-07 11 29 56](https://cloud.githubusercontent.com/assets/7507279/11618050/556caffe-9cd9-11e5-999a-dacb7db7be66.png)

This change enables a field table to scroll in the case of too long fields.

![2015-12-07 11 40 20 3](https://cloud.githubusercontent.com/assets/7507279/11618057/663e464e-9cd9-11e5-91fc-ef3c4a5e660c.png)

Please consider this proposal.
Regards,