### PR TITLE
Fix warning of log4j when --log-backups option is not used

### DIFF
--- a/lib/norikra/logger.rb
+++ b/lib/norikra/logger.rb
@@ -78,17 +78,18 @@ module Norikra
         else
           # DailyRollingFileAppender ?
           # http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/DailyRollingFileAppender.html
+          max_backup_index = opts[:backups] || LOGFILE_DEFAULT_MAX_BACKUP_INDEX
           norikra_log = File.join(logdir, 'norikra.log')
           p.setProperty('log4j.appender.default', 'org.apache.log4j.RollingFileAppender')
           p.setProperty('log4j.appender.default.File', norikra_log)
           p.setProperty('log4j.appender.default.MaxFileSize', opts[:filesize] || LOGFILE_DEFAULT_MAX_SIZE)
-          p.setProperty('log4j.appender.default.MaxBackupIndex', opts[:backups].to_s || LOGFILE_DEFAULT_MAX_BACKUP_INDEX.to_s)
+          p.setProperty('log4j.appender.default.MaxBackupIndex', max_backup_index.to_s)
 
           builtin_log = File.join(logdir, 'builtin.log')
           p.setProperty('log4j.appender.builtin', 'org.apache.log4j.RollingFileAppender')
           p.setProperty('log4j.appender.builtin.File', builtin_log)
           p.setProperty('log4j.appender.builtin.MaxFileSize', opts[:filesize] || LOGFILE_DEFAULT_MAX_SIZE)
-          p.setProperty('log4j.appender.builtin.MaxBackupIndex', opts[:backups].to_s || LOGFILE_DEFAULT_MAX_BACKUP_INDEX.to_s)
+          p.setProperty('log4j.appender.builtin.MaxBackupIndex', max_backup_index.to_s)
         end
         p.setProperty('log4j.rootLogger', "#{level},default")
         org.apache.log4j.PropertyConfigurator.configure(p)


### PR DESCRIPTION
A warning of log4j occurred when `--logdir` was used and `--log-backups` was not used.

```
$ bundle exec bin/norikra start -l ./
The signal IOT is in use by the JVM and will not work correctly on this platform
The signal CLD is in use by the JVM and will not work correctly on this platform
The signal EXIT is in use by the JVM and will not work correctly on this platform
log4j:WARN Failed to set property [maxBackupIndex] to value "".
log4j:WARN Failed to set property [maxBackupIndex] to value "".
```

This warning occurs because `opts[:backups].to_s` is an empty character, so `LOGFILE_DEFAULT_MAX_BACKUP_INDEX` is not set.
https://github.com/norikra/norikra/blob/v1.4.0/lib/norikra/logger.rb#L85

I fixed it so that the above cause does not occur.

