### PR TITLE
openjdk6 and oraclejdk7 is no longer available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ rvm:
   - jruby-head
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
-  - openjdk6
 matrix:
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/8199
https://github.com/travis-ci/travis-ci/issues/7884