### PR TITLE
flush after puts "working on #{$PID}"

### DIFF
--- a/lib/norikra/server.rb
+++ b/lib/norikra/server.rb
@@ -81,6 +81,7 @@ module Norikra
         STDOUT.reopen(outfile)
         STDERR.reopen(outfile)
         puts "working on #{$PID}"
+        STDOUT.flush
       end
 
       @shutoff = conf[:shutoff][:enabled] || false


### PR DESCRIPTION
CLI daemonize process infinite wait for server process
becaurse STDOUT.sync is false in jruby 9k