### PR TITLE
Add docker build

### DIFF
--- a/docker/BUILDING.md
+++ b/docker/BUILDING.md
@@ -1,0 +1,20 @@
+# Build
+
+There are two build args baked in:
+
+* `jruby_version` which defaults to 9.2
+* `norikra_version` which must be specified
+
+Eg:
+
+```
+docker build --build-arg norikra_version=1.5.1 -t norikra:1.5.1
+```
+
+# Push
+
+```
+docker tag norikra:1.5.1 ${your_repo}/norikra:1.5.1
+docker push ${your_repo}/norikra:1.5.1
+```
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+ARG jruby_version=9.2
+
+FROM jruby:${jruby_version} AS build
+MAINTAINER Wade Rossmann <wrossmann@gmail.com>
+
+ARG norikra_version
+RUN gem install norikra --version ${norikra_version}
+
+FROM jruby:${jruby_version} AS deploy
+COPY --from=build /usr/local/bundle/ /usr/local/bundle/
+
+EXPOSE 26571 26578
+
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["/usr/local/bundle/bin/norikra", "start"]
+


### PR DESCRIPTION
While there are a fair number of people publishing their own images for Norikra, many are outdated, contain publisher-specific esoterica, or have questionable build workflows. This Dockerfile is simple, based on the official JRuby image, and leverages current best practices.

Ideally you could spin up an official repo somewhere like Dockerhub or Quay.io and use the included command reference to push new versions as you release them.

LMK if there's anything you'd like to see added.